### PR TITLE
Fix VS Code status bar coloring

### DIFF
--- a/Gray Matter Dark-color-theme.json
+++ b/Gray Matter Dark-color-theme.json
@@ -31,6 +31,8 @@
 		"sideBarSectionHeader.background": "#1A191A",
 		"sideBarSectionHeader.foreground": "#BEBEBE",
 		"statusBar.background": "#1A191A",
+		"statusBar.debuggingBackground": "#1A191A",
+		"statusBar.noFolderBackground": "#1A191A",
 		"statusBar.foreground": "#BEBEBE",
 		"tab.activeBackground": "#222122",
 		"tab.activeBorder": "#222122",

--- a/Gray Matter Light-color-theme.json
+++ b/Gray Matter Light-color-theme.json
@@ -32,6 +32,8 @@
 		"sideBarSectionHeader.background": "#F5F5F5",
 		"sideBarSectionHeader.foreground": "#3C3C3C",
 		"statusBar.background": "#F5F5F5",
+		"statusBar.debuggingBackground": "#F5F5F5",
+		"statusBar.noFolderBackground": "#F5F5F5",
 		"statusBar.foreground": "#3C3C3C",
 		"tab.activeBackground": "#EDEDED",
 		"tab.activeBorder": "#EDEDED",


### PR DESCRIPTION
VS Code has different modes for the status bar color. In the default
condition it is purple when opened with just a file (no folder) or in
debugging mode. Apart from getting unreadable due to the foreground
color, this also destroyed the themes aesthetics.
![image](https://user-images.githubusercontent.com/6529243/54742254-2ef39f00-4bc1-11e9-94ff-034189d04a94.png)
