### PR TITLE
docs: update preview image URLs on the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ A pair of colour schemes for writing Markdown in Sublime Text, Visual Studio Cod
 
 #### Light Theme
 
-![Light Theme](https://github.com/philipbelesky/gray-matter/raw/master/screenshots/light.jpg)
+![Light Theme](https://raw.githubusercontent.com/philipbelesky/gray-matter/develop/screenshots/light.jpg)
 
 #### Dark Theme
 
-![Dark Theme](https://github.com/philipbelesky/gray-matter/raw/master/screenshots/dark.jpg)
+![Dark Theme](https://raw.githubusercontent.com/philipbelesky/gray-matter/develop/screenshots/dark.jpg)
 
 ## Sublime Text Installation
 


### PR DESCRIPTION
Noticed that Markdown image previews of the VS Code extension were broken,
as GitHub has changed the URL structure at some point during past few years.

Made the two URL adjustments to the `README.md`, allowing people to see what the theme looks like.

- Update preview image URLs on the README.md